### PR TITLE
181315789 change overview width

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Install Ruby (2.6)
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6.6
     - name: Build and test with RSpec

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,7 +22,8 @@ Style/CommentAnnotation:
     - OPTIMIZE
     - HACK
     - REVIEW
-
+Layout/EndOfLine:
+   Enabled: False
 ##################### Metrics ##################################
 
 ##################### Rails ##################################

--- a/Gemfile
+++ b/Gemfile
@@ -297,7 +297,3 @@ group :development, :test do
   # as development/test database
   gem 'sqlite3'
 end
-
-group :production do
-  gem 'pg'
-end

--- a/app/assets/javascripts/fullcalendar-scheduler/main.js
+++ b/app/assets/javascripts/fullcalendar-scheduler/main.js
@@ -1,3 +1,0 @@
-var calendar = new Calendar(calendarEl, {
-    schedulerLicenseKey: 'GPL-My-Project-Is-Open-Source'
-  });

--- a/app/assets/javascripts/fullcalendar.js.erb
+++ b/app/assets/javascripts/fullcalendar.js.erb
@@ -1,21 +1,22 @@
 $( document ).ready(function() {
-    let calendarEl = document.getElementById('vert-schedule-full-calendar');
+        let calendarEl = document.getElementById('vert-schedule-full-calendar');
     if (!calendarEl) return; //check that we need a vertical schedule
     let $fullCalendar = $('#fullcalendar');
 
-    let license_key = "<%= Rails.configuration.fullcalendar[:license_key] %>";
+    let license_key = "<%= Rails.configuration.fullcalendar[:license_key]%>";
 
     let offset = $fullCalendar.data('tzOffset');
     let interval = $fullCalendar.data('minInterval');
     let localOffset = (new Date()).getTimezoneOffset()/60;
-    let event_num_days = $fullCalendar.data('end_date') - $fullCalendar.data('start_date')
-    let width = [4, event_num_days].min()
     let startTime = $fullCalendar.data('startHour') - offset - localOffset;
     let endTime = $fullCalendar.data('endHour') - offset - localOffset;
+    let startDate = new Date($fullCalendar.data('startDate'));
+    let endDate = new Date($fullCalendar.data('endDate'));
+    let event_num_days = (endDate.getTime() - startDate.getTime())/ (1000 * 3600 * 24);
+    let width = Math.min(4, event_num_days);
     let localName = Intl.DateTimeFormat().resolvedOptions().timeZone;
     // Program Hours * Minutes / Interval * Min Row Height for an event.
     let contentHeight = Math.max(400, (endTime - startTime) * 60 / interval * 16);
-
     // UTC JS offsets are "-1 *" of how they're displayed.
     let operator = localOffset < 0 ? '+' : '-';
     $('.js-localTimezone').text(`(${localName} UTC ${operator}${Math.abs(localOffset)})`);
@@ -65,7 +66,7 @@ $( document ).ready(function() {
       views: {
         resourceTimeGridFourDay: {
           type: 'resourceTimeGrid',
-          duration: { days: width},
+          duration: { days: width },
           buttonText: 'overview',
           datesAboveResources: true
         },

--- a/app/assets/javascripts/fullcalendar.js.erb
+++ b/app/assets/javascripts/fullcalendar.js.erb
@@ -1,5 +1,5 @@
 $( document ).ready(function() {
-        let calendarEl = document.getElementById('vert-schedule-full-calendar');
+    let calendarEl = document.getElementById('vert-schedule-full-calendar');
     if (!calendarEl) return; //check that we need a vertical schedule
     let $fullCalendar = $('#fullcalendar');
 

--- a/app/assets/javascripts/fullcalendar.js.erb
+++ b/app/assets/javascripts/fullcalendar.js.erb
@@ -8,6 +8,8 @@ $( document ).ready(function() {
     let offset = $fullCalendar.data('tzOffset');
     let interval = $fullCalendar.data('minInterval');
     let localOffset = (new Date()).getTimezoneOffset()/60;
+    let event_num_days = $fullCalendar.data('end_date') - $fullCalendar.data('start_date')
+    let width = [4, event_num_days].min()
     let startTime = $fullCalendar.data('startHour') - offset - localOffset;
     let endTime = $fullCalendar.data('endHour') - offset - localOffset;
     let localName = Intl.DateTimeFormat().resolvedOptions().timeZone;
@@ -63,7 +65,7 @@ $( document ).ready(function() {
       views: {
         resourceTimeGridFourDay: {
           type: 'resourceTimeGrid',
-          duration: { days: 4 },
+          duration: { days: width},
           buttonText: 'overview',
           datesAboveResources: true
         },

--- a/app/assets/stylesheets/fullcalendar-scheduler/main.css
+++ b/app/assets/stylesheets/fullcalendar-scheduler/main.css
@@ -1,3 +1,0 @@
-html {
-    scroll-behavior: smooth;
-  }


### PR DESCRIPTION
+ Make the overview "width" 2 or 3 days for events < 4 days. 
+ Fix the issue in which the calendar does not display by removing the fullcalendar-scheduler directory in app/assets/javascripts and app/assets/stylesheets