### PR TITLE
Hopefully create partial for timezone adjustment

### DIFF
--- a/app/views/shared/_timezone_adjust.html.haml
+++ b/app/views/shared/_timezone_adjust.html.haml
@@ -1,0 +1,4 @@
+- if current_user.timezone
+  = time.in_time_zone(current_user.time_zone)
+- else
+  = time.in_time_zone(default)


### PR DESCRIPTION
Partial should be passed two values, "time", the UTC time to be adjusted, and "default", the default timezone to use if the user has no timezone set.

**Checklist**

- [ ] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [ ] My branch is up-to-date with the upstream `master` branch.
- [ ] The tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [ ] I have added necessary documentation (if appropriate).

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**

<!-- List the issue number resolved with this change; if there is no open issue, describe the problem this request solves -->

-

**Changes proposed in this pull request:**

<!-- Summarize the changes, using declarative language. -->

-
